### PR TITLE
Show local collections in the collection modal (for nearby graves)

### DIFF
--- a/app/assets/javascripts/read/src/actions/collections.js
+++ b/app/assets/javascripts/read/src/actions/collections.js
@@ -55,10 +55,11 @@ function receiveCollections(geojson) {
  *
  * @param {Object} feature
  */
-export function selectCollection(feature) {
+export function selectCollection(feature, nearby) {
   return {
     type: SELECT_COLLECTION,
     feature: feature,
+    nearby: nearby,
   };
 }
 

--- a/app/assets/javascripts/read/src/components/collection-markers.js
+++ b/app/assets/javascripts/read/src/components/collection-markers.js
@@ -80,7 +80,9 @@ export default class extends Component {
 
     // SELECT
     this.group.on('click', e => {
-      this.props.selectCollection(e.layer.options.feature);
+      let localItems = this.tree.search(this.toRbushTreeItem(e.layer));
+      let localMarkers = localItems.map((item) => this.idToMarker[item.id]);
+      this.props.selectCollection(e.layer.options.feature, localMarkers);
     });
 
     window.markers = this;

--- a/app/assets/javascripts/read/src/components/collection-modal.js
+++ b/app/assets/javascripts/read/src/components/collection-modal.js
@@ -19,6 +19,7 @@ import FieldDate from './field-date';
   state => ({
     feature: state.collections.selected,
     show: state.collections.showModal,
+    nearby: state.collections.nearby,
   }),
 
   actions
@@ -31,6 +32,19 @@ export default class extends Component {
     feature: PropTypes.object,
     show: PropTypes.bool.isRequired,
   };
+  
+  closeAndOpen(near) {
+    this.onHide();
+    this.props.selectCollection(near.options.feature, this.props.nearby);
+  }
+
+  markerClasses(num_graves) {
+    let classes = 'collection'
+    if (!num_graves) {
+      classes += ' no-count'
+    }
+    return classes;
+  }
 
 
   /**
@@ -107,6 +121,46 @@ export default class extends Component {
               pinyin={c.notice.title_p}
             />
 
+          </Modal.Body>
+
+          { this.props.nearby.length > 1 &&
+            <Modal.Header>
+              <Modal.Title componentClass='h5'>
+                Graves nearby
+              </Modal.Title>
+            </Modal.Header>
+          }
+
+          <Modal.Body>
+            {this.props.nearby.map((near) => {
+              if (near.options.feature.id !== this.props.feature.id) {
+                return (
+                  <div
+                    className='collection-container'
+                    key={near.options.feature.id}
+                    onClick={this.closeAndOpen.bind(this, near)}
+                  >
+                    <div
+                      className='collection-marker'
+                    >
+                      <div
+                        className={this.markerClasses(near.options.feature.properties.num_graves)}
+                        style={{ width: near.options.radius * 2, height: near.options.radius * 2 }}
+                      />
+                    </div>
+                    <div className='collection-text collection-title'>
+                      Grave Collection #{near.options.feature.id}
+                    </div>
+                    <div className='collection-text'>
+                        <FieldNumeric
+                          field="Number of Graves Relocated"
+                          value={near.options.feature.properties.num_graves}
+                        />
+                    </div>
+                  </div>
+                );
+              }
+            })}
           </Modal.Body>
 
         </Modal>

--- a/app/assets/javascripts/read/src/reducers/collections.js
+++ b/app/assets/javascripts/read/src/reducers/collections.js
@@ -36,6 +36,7 @@ const handlers = {
   [SELECT_COLLECTION]: (state, action) => ({
     showModal: true,
     selected: action.feature,
+    nearby: action.nearby,
   }),
 
   [UNSELECT_COLLECTION]: () => ({

--- a/app/assets/javascripts/read/test/specs/collection-markers.js
+++ b/app/assets/javascripts/read/test/specs/collection-markers.js
@@ -53,6 +53,16 @@ describe('Collection Markers', function() {
 
   });
 
+  it('adds markers to rtree that is searchable', function() {
+    utils.respondCollections(addMarkersJSON);
+    expect(markers.tree.collides({
+      minX: 2,
+      maxX: 4,
+      minY: 3,
+      maxY: 5,
+    })).toBe(true)
+  });
+
 
   describe('hover', function() {
 

--- a/app/assets/stylesheets/read/index.less
+++ b/app/assets/stylesheets/read/index.less
@@ -20,3 +20,4 @@
 @import "reset-button";
 @import "controls";
 @import "legend";
+@import "modal-markers";

--- a/app/assets/stylesheets/read/modal-markers.less
+++ b/app/assets/stylesheets/read/modal-markers.less
@@ -1,0 +1,44 @@
+
+  // Collection markers
+.modal-dialog {
+  .collection-title {
+    font-weight: bold;
+  }
+
+  .collection-container {
+    height: 60px;
+    position: relative;
+    cursor: pointer;
+    &:hover, &:active {
+      background-color: darken(white, 10%);
+      border-radius: 3px;
+    }
+  }
+
+  .collection-text {
+    display: block;
+    margin-left: 70px;
+  }
+
+  .collection-marker {
+    display: inline-block;
+    position: absolute;
+    height: 60px;
+    width: 60px;
+  }
+
+  .collection {
+    border: 2px solid @color-yellow;
+    border-radius: 99999px;
+    background-color: fade(darken(@color-blue, 25%), 20%);
+    margin: 0 auto;
+    top: 50%;
+    position: relative;
+    transform: translateY(-50%);
+
+    &.no-count {
+      background-color: fade(darken(@color-blue, 10%), 70%);
+      border: none;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "moment": "2.11.2",
     "mousetrap": "1.5.3",
     "nouislider": "8.3.0",
+    "rbush": "^2.0.1",
     "react": "0.14.7",
     "react-bootstrap": "0.27.3",
     "react-dom": "0.14.7",


### PR DESCRIPTION
Closes #121

Nearby graves are shown in the modal and are clickable. When clicked the clicked grave info is shown in modal

<img width="806" alt="screen shot 2017-02-08 at 1 48 55 pm" src="https://cloud.githubusercontent.com/assets/1656824/22752139/6fafcf1c-ee05-11e6-9ab6-5ca4b9e39a69.png">
