### PR TITLE
Fixes #208. Adding a way to point to coordinates without those being a grave location

### DIFF
--- a/app/assets/javascripts/read/src/components/collection-markers.js
+++ b/app/assets/javascripts/read/src/components/collection-markers.js
@@ -111,25 +111,38 @@ export default class extends Component {
 
       _.each(this.props.geojson.features, f => {
 
-        let date = moment(f.properties.notice.deadline);
+        let marker;
+        if (!f.properties.no_marker) {
 
-        let cx = classNames('collection', {
-          nocount: !f.properties.num_graves,
-        });
+          let date = moment(f.properties.notice.deadline);
 
-        let marker = L.circleMarker(f.geometry.coordinates, {
-          feature: f,
-          className: cx,
-          date,
-        });
+          let cx = classNames('collection', {
+            nocount: !f.properties.num_graves,
+          });
 
-        // Size by grave count.
-        let r = countToRadius(f.properties.num_graves);
-        marker.setRadius(r);
+          marker = L.circleMarker(f.geometry.coordinates, {
+            feature: f,
+            className: cx,
+            date,
+          });
 
-        // Insert the item representation to the rtree
-        let item = this.toRbushTreeItem(marker);
-        this.tree.insert(item);
+          // Size by grave count.
+          let r = countToRadius(f.properties.num_graves);
+          marker.setRadius(r);
+
+          // Insert the item representation to the rtree
+          let item = this.toRbushTreeItem(marker);
+          this.tree.insert(item);
+
+        } else {
+          marker = L.circleMarker(f.geometry.coordinates, {
+            feature: f,
+            className: classNames('collection', 'nomarker')
+          });
+          marker.off('click');
+          marker.off('onmouseover');
+          marker.setRadius(0);
+        }
 
         let label = (
           f.properties.town_p ||
@@ -137,12 +150,14 @@ export default class extends Component {
           f.properties.province_p
         );
 
-        // Attach popup.
-        marker.bindPopup(label, {
-          minWidth: 0,
-          closeButton: false,
-          autoPan: false,
-        });
+        if (label) {
+          // Attach popup.
+          marker.bindPopup(label, {
+            minWidth: 0,
+            closeButton: false,
+            autoPan: false,
+          });
+        }
 
         this.idToMarker[f.id] = marker;
         this.group.addLayer(marker);

--- a/app/assets/javascripts/read/src/components/collection-modal.js
+++ b/app/assets/javascripts/read/src/components/collection-modal.js
@@ -52,7 +52,7 @@ export default class extends Component {
    */
   render() {
 
-    if (this.props.feature) {
+    if (this.props.feature && !this.props.feature.properties.no_marker) {
 
       let c = this.props.feature.properties;
 

--- a/app/assets/javascripts/read/test/specs/collection-markers.js
+++ b/app/assets/javascripts/read/test/specs/collection-markers.js
@@ -34,7 +34,7 @@ describe('Collection Markers', function() {
 
     utils.respondCollections(addMarkersJSON);
 
-    expect(markers.group.getLayers().length).toEqual(3);
+    expect(markers.group.getLayers().length).toEqual(4);
 
     expect(markers.idToMarker[1].getLatLng()).toEqual({
       lng: 1,
@@ -49,6 +49,11 @@ describe('Collection Markers', function() {
     expect(markers.idToMarker[3].getLatLng()).toEqual({
       lng: 5,
       lat: 6,
+    });
+
+    expect(markers.idToMarker[4].getLatLng()).toEqual({
+      lng: 7,
+      lat: 8,
     });
 
   });
@@ -152,5 +157,52 @@ describe('Collection Markers', function() {
 
   });
 
+  describe('when no_marker is true', function() {
+
+    let marker;
+
+    beforeEach(function() {
+
+      utils.respondCollections(highlightJSON);
+
+      marker = markers.idToMarker[2];
+
+    });
+
+    it('does not show marker', function() {
+      expect('path.collection.nomarker').toExist();
+    });
+
+    it('does not show popup', function() {
+
+      markers.group.fire('mouseover', {
+        layer: marker
+      });
+
+      // leaflet popup would be visible if a label was assigned to the marker
+      expect('.leaflet-popup').not.toExist();
+      // collection is highlighted but not visible by applying CSS classes
+      expect('path.collection.nomarker.highlight').toExist();
+
+      markers.group.fire('mouseout', {
+        layer: marker
+      });
+
+      assert.noCollectionHighlighted();
+
+    });
+
+    it('does not show modal', function() {
+
+      markers.group.fire('click', {
+        layer: marker
+      });
+
+      expect('#collection-2.modal').not.toBeVisible();
+
+    });
+
+
+  });
 
 });

--- a/app/assets/stylesheets/read/svg.less
+++ b/app/assets/stylesheets/read/svg.less
@@ -25,6 +25,15 @@ svg {
       fill-opacity: 0.7;
     }
 
+    &.nomarker {
+      stroke-width: 0;
+      fill-opacity: 0;
+
+      &.highlight {
+        fill-opacity: 0;
+      }
+    }
+
     &.highlight {
       fill: @color-yellow;
       fill-opacity: 0.7;

--- a/app/controllers/api/collections_controller.rb
+++ b/app/controllers/api/collections_controller.rb
@@ -22,7 +22,8 @@ module API
         :town_p,
         :town_c,
         :tag_list,
-        :notice
+        :notice,
+        :no_marker
       )
 
       respond_to do |format|

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -24,6 +24,7 @@
 #  county_id   :integer
 #  town_id     :integer
 #  legacy_id   :integer
+#  no_marker   :boolean          default: false
 #
 
 class Collection < ActiveRecord::Base

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -102,6 +102,12 @@ RailsAdmin.config do |config|
       help 'Optional - WKT format: POINT(-71.064544 42.28787)'
     end
 
+    configure :no_marker do
+      show
+      help 'Optional - When checked, no marker, popup, or modal ' \
+           'will be rendered on the map'
+    end
+
     edit do
       include_all_fields
       field :geometry

--- a/db/migrate/20171030182504_add_no_marker_to_collections.rb
+++ b/db/migrate/20171030182504_add_no_marker_to_collections.rb
@@ -1,0 +1,5 @@
+class AddNoMarkerToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :no_marker, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229003926) do
+ActiveRecord::Schema.define(version: 20171030182504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20160229003926) do
     t.integer  "county_id"
     t.integer  "town_id"
     t.integer  "legacy_id"
+    t.boolean  "no_marker",                                            default: false
   end
 
   add_index "collections", ["county_id"], name: "index_collections_on_county_id", using: :btree

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -24,6 +24,7 @@
 #  county_id   :integer
 #  town_id     :integer
 #  legacy_id   :integer
+#  no_marker   :boolean          default: false
 #
 
 FactoryGirl.define do

--- a/spec/fixtures/collection_markers_spec.rb
+++ b/spec/fixtures/collection_markers_spec.rb
@@ -23,6 +23,13 @@ describe 'Collection Markers', type: :feature do
       geometry: Helpers::Geo.point(5, 6),
     )
 
+    create(
+      :collection,
+      id: 4,
+      geometry: Helpers::Geo.point(7, 8),
+      no_marker: true
+    )
+
     visit('api/collections.json')
 
     write_collection_fixture('collection-markers', 'add-markers', page)
@@ -55,6 +62,13 @@ describe 'Collection Markers', type: :feature do
       province_p: 'province',
     )
 
+    create(
+      :collection,
+      id: 4,
+      geometry: Helpers::Geo.point(0, 0),
+      no_marker: true
+    )
+
     visit('api/collections.json')
 
     write_collection_fixture('collection-markers', 'show-tooltips', page)
@@ -67,6 +81,13 @@ describe 'Collection Markers', type: :feature do
       :collection,
       id: 1,
       geometry: Helpers::Geo.point(1, 1),
+    )
+
+    create(
+      :collection,
+      id: 2,
+      geometry: Helpers::Geo.point(2, 2),
+      no_marker: true
     )
 
     visit('api/collections.json')

--- a/spec/fixtures/collection_modal_spec.rb
+++ b/spec/fixtures/collection_modal_spec.rb
@@ -6,6 +6,8 @@ describe 'Collection Markers', type: :feature do
   it 'show-modal' do
 
     create(:collection, id: 1, geometry: Helpers::Geo.point(0, 0))
+    create(:collection, id: 2, geometry: Helpers::Geo.point(1, 1),
+                        no_marker: true)
 
     visit('api/collections.json')
 


### PR DESCRIPTION
On the `Collection` model there is now a `no_marker` boolean field (rendered as a checkbox in the admin). Default behavior is unchecked. When checked, a grave location will not show the marker, tooltip or popup, acting as a mere pair of coordinates to point to. Some sort of label can be given and will be displayed when the link that points to it gets hovered over.