### PR TITLE
Style for article DOI in title/author section

### DIFF
--- a/app/assets/stylesheets/read/header.less
+++ b/app/assets/stylesheets/read/header.less
@@ -49,6 +49,13 @@
     font-weight: lighter;
   }
 
+  .doi {
+    display: block;
+    text-align: center;
+    margin-bottom: 1em;
+    margin-top: -1em;
+  }
+
   p.blurb {
     margin-top: 2em;
     font-size: 1.4em;


### PR DESCRIPTION
Adding style class suggested by @versae to enable addition of an optional article DOI on article read/ page between author name/affiliation and the beginning of the blurb.
The actual HTML element would be inserted at the beginning of the blurb text, using the admin editor interface, like this:
`<span class="doi">DOI: XXXX/yyy</span>`